### PR TITLE
Avoid running CI for PR in draft state

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, devel]
   pull_request:
-    branches: [main, master]
+    branches: [main, devel]
 
 name: R-CMD-check
 

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -10,10 +10,9 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.config.os }}
-
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -13,6 +13,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:
@@ -27,6 +28,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: https://inla.r-inla-download.org/R/stable
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, any::bookdown, local::.


### PR DESCRIPTION
Avoid running the CI if a PR is only a draft.