### PR TITLE
Update tutorial dataset retrieval

### DIFF
--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -2,29 +2,50 @@
 #' to a folder in th user's home directory or a folder
 #' specified in their use config file.
 #'
-#' @param dataset Name of dataset to retrieve, either covid or hydro
+#' @param dataset Name of dataset to retrieve
+#' @param force_retrieval Force update of dataset information
+#'
 #' @return NULL
 #' @export
-retrieve_tutorial_data <- function(dataset, filename) {
+retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
   dataset <- base::tolower(dataset)
-  # TODO - update this to retrieve a JSON/YAML of available tutorial
-  # datasets
-  if (dataset == "covid") {
-    filename <- "covid19_data.tar.bz2"
-  } else if (dataset == "hydro") {
-    filename <- "hydro_data.tar.bz2"
-  } else if (dataset == "covid_mcmc") {
-    filename <- "covid19_data2.tar.bz2"
-  } else {
-    stop("Invalid dataset name.")
-  }
 
   download_cache_folder <- fs::path(fs::path_home(), "fdmr", "download_cache")
-  # We extract each dataset into its own directory in case we have the same filenames
-  # in different datasets
-  extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
 
-  download_path <- fs::path(download_cache_folder, filename)
+  retrieval_info_file <- fs::path(download_cache_folder, "metadata.json")
+  dataset_info_file <- fs::path(download_cache_folder, "datasets.json")
+
+  if (fs::file_exists(retrieval_info_file)) {
+    retrieval_info <- jsonlite::read_json(retrieval_info_file)
+
+    last_retrieved_str <- retrieval_info$datasets$datasets_retrieved
+    last_retrieved <- lubridate::ymd_hms(last_retrieved_str)
+
+    print(last_retrieved)
+
+    
+
+    retrieval_period <- lubridate::period(6, units = "hours")
+
+    print(as.logical(lubridate::interval(last_retrieved, lubridate::now()) > retrieval_period))
+
+    stop("waaa")
+
+    if (retrieve) {
+      # Retrieve the list of known datasets
+      utils::download.file(url = "https://github.com/4DModeller/fdmr_data/raw/main/datasets.json", dataset_info_file)
+      # Set the current time of retrieval and write out the JSON
+      retrieval_info$datasets$datasets_retrieved <- lubridate::format_ISO8601(lubridate::now())
+      jsonlite::write_json(retrieval_info, retrieval_info_file)
+    }
+  } else {
+    # Retrieve the list of known datasets
+    utils::download.file(url = "https://github.com/4DModeller/fdmr_data/raw/main/datasets.json", dataset_info_file)
+    retrieval_info <- list("datasets" = list("retrieved" = lubridate::format_ISO8601(lubridate::now())))
+    jsonlite::write_json(retrieval_info, path = retrieval_info_file)
+  }
+
+  extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
 
   if (!fs::dir_exists(extract_path)) {
     fs::dir_create(extract_path, recurse = TRUE)
@@ -34,10 +55,24 @@ retrieve_tutorial_data <- function(dataset, filename) {
     fs::dir_create(download_cache_folder, recurse = TRUE)
   }
 
-  # Check the cache file
-  if (!fs::file_exists(download_path)) {
-    data_url <- base::paste0("https://github.com/4DModeller/fdmr_data/raw/main/", filename)
-    utils::download.file(url = data_url, destfile = download_path)
+  dataset_info <- jsonlite::read_json(dataset_info_file)
+  available_datasets <- dataset_info$datasets
+
+  if (dataset %in% available_datasets) {
+    filename <- dataset_info[[dataset]]$filename
+    download_path <- fs::path(download_cache_folder, filename)
+
+    last_updated <- lubridate::ymd(dataset_info[[dataset]]$last_updated)
+    mod_time <- fs::file_info(download_path)$modification_time
+
+    needs_updating <- mod_time < last_updated
+
+    if (!fs::file_exists(download_path) || needs_updating) {
+      data_url <- base::paste0("https://github.com/4DModeller/fdmr_data/raw/main/", filename)
+      utils::download.file(url = data_url, destfile = download_path)
+    }
+  } else {
+    stop("Invalid dataset, please see available datasets at https://github.com/4DModeller/fdmr_data")
   }
 
   archive::archive_extract(download_path, dir = extract_path)

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -1,9 +1,7 @@
-#' Retrieve the tutorial datasets and unpack them
-#' to a folder in th user's home directory or a folder
-#' specified in their use config file.
+#' Retrieve a tutorial dataset and unpacks it to ~/fdmr/tutorial_data
 #'
 #' @param dataset Name of dataset to retrieve
-#' @param force_retrieval Force update of dataset information
+#' @param force_update Force retrieval of metadata and dataset
 #'
 #' @return NULL
 #' @export

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -28,7 +28,7 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
     retrieval_period <- lubridate::period(6, units = "hours")
     retrieve <- lubridate::interval(lubridate::now(), last_retrieved) > retrieval_period
 
-    if (retrieve) {
+    if (retrieve || force_update) {
       # Retrieve the list of known datasets
       utils::download.file(url = "https://github.com/4DModeller/fdmr_data/raw/main/datasets.json", dataset_info_file)
       # Set the current time of retrieval and write out the JSON
@@ -48,8 +48,6 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
     fs::dir_create(extract_path, recurse = TRUE)
   }
 
-
-
   dataset_info <- jsonlite::read_json(dataset_info_file)
   available_datasets <- dataset_info$datasets
 
@@ -66,7 +64,7 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
       needs_updating <- TRUE
     }
 
-    if (!fs::file_exists(download_path) || needs_updating) {
+    if (force_update || !fs::file_exists(download_path) || needs_updating) {
       data_url <- base::paste0("https://github.com/4DModeller/fdmr_data/raw/main/", filename)
       utils::download.file(url = data_url, destfile = download_path)
     }

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -11,38 +11,35 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
   dataset <- base::tolower(dataset)
 
   download_cache_folder <- fs::path(fs::path_home(), "fdmr", "download_cache")
+  if (!fs::dir_exists(download_cache_folder)) {
+    fs::dir_create(download_cache_folder, recurse = TRUE)
+  }
 
-  retrieval_info_file <- fs::path(download_cache_folder, "metadata.json")
+  file_metadata_file <- fs::path(download_cache_folder, "metadata.json")
   dataset_info_file <- fs::path(download_cache_folder, "datasets.json")
 
-  if (fs::file_exists(retrieval_info_file)) {
-    retrieval_info <- jsonlite::read_json(retrieval_info_file)
+  if (fs::file_exists(file_metadata_file)) {
+    retrieval_info <- jsonlite::read_json(file_metadata_file)
 
-    last_retrieved_str <- retrieval_info$datasets$datasets_retrieved
+    last_retrieved_str <- retrieval_info$datasets$retrieved
     last_retrieved <- lubridate::ymd_hms(last_retrieved_str)
 
-    print(last_retrieved)
-
-    
-
+    # We'll retrieve the list of datasets every 6 hours
     retrieval_period <- lubridate::period(6, units = "hours")
-
-    print(as.logical(lubridate::interval(last_retrieved, lubridate::now()) > retrieval_period))
-
-    stop("waaa")
+    retrieve <- lubridate::interval(lubridate::now(), last_retrieved) > retrieval_period
 
     if (retrieve) {
       # Retrieve the list of known datasets
       utils::download.file(url = "https://github.com/4DModeller/fdmr_data/raw/main/datasets.json", dataset_info_file)
       # Set the current time of retrieval and write out the JSON
       retrieval_info$datasets$datasets_retrieved <- lubridate::format_ISO8601(lubridate::now())
-      jsonlite::write_json(retrieval_info, retrieval_info_file)
+      jsonlite::write_json(retrieval_info, file_metadata_file)
     }
   } else {
     # Retrieve the list of known datasets
     utils::download.file(url = "https://github.com/4DModeller/fdmr_data/raw/main/datasets.json", dataset_info_file)
     retrieval_info <- list("datasets" = list("retrieved" = lubridate::format_ISO8601(lubridate::now())))
-    jsonlite::write_json(retrieval_info, path = retrieval_info_file)
+    jsonlite::write_json(retrieval_info, path = file_metadata_file)
   }
 
   extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
@@ -51,30 +48,32 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
     fs::dir_create(extract_path, recurse = TRUE)
   }
 
-  if (!fs::dir_exists(download_cache_folder)) {
-    fs::dir_create(download_cache_folder, recurse = TRUE)
-  }
+
 
   dataset_info <- jsonlite::read_json(dataset_info_file)
   available_datasets <- dataset_info$datasets
 
-  if (dataset %in% available_datasets) {
-    filename <- dataset_info[[dataset]]$filename
+  if (dataset %in% names(available_datasets)) {
+    filename <- available_datasets[[dataset]]$filename
     download_path <- fs::path(download_cache_folder, filename)
 
-    last_updated <- lubridate::ymd(dataset_info[[dataset]]$last_updated)
+    last_updated <- lubridate::ymd(available_datasets[[dataset]]$last_updated)
     mod_time <- fs::file_info(download_path)$modification_time
 
+    # TODO - this might not work on Windows, check
     needs_updating <- mod_time < last_updated
+    if (length(needs_updating) == 0) {
+      needs_updating <- TRUE
+    }
 
     if (!fs::file_exists(download_path) || needs_updating) {
       data_url <- base::paste0("https://github.com/4DModeller/fdmr_data/raw/main/", filename)
       utils::download.file(url = data_url, destfile = download_path)
     }
+
+    archive::archive_extract(download_path, dir = extract_path)
+    base::cat("\nTutorial data extracted to ", extract_path, "\n")
   } else {
     stop("Invalid dataset, please see available datasets at https://github.com/4DModeller/fdmr_data")
   }
-
-  archive::archive_extract(download_path, dir = extract_path)
-  base::cat("\nTutorial data extracted to ", extract_path, "\n")
 }

--- a/man/retrieve_tutorial_data.Rd
+++ b/man/retrieve_tutorial_data.Rd
@@ -6,10 +6,12 @@
 to a folder in th user's home directory or a folder
 specified in their use config file.}
 \usage{
-retrieve_tutorial_data(dataset, filename)
+retrieve_tutorial_data(dataset, force_update = FALSE)
 }
 \arguments{
-\item{dataset}{Name of dataset to retrieve, either covid or hydro}
+\item{dataset}{Name of dataset to retrieve}
+
+\item{force_retrieval}{Force update of dataset information}
 }
 \description{
 Retrieve the tutorial datasets and unpack them


### PR DESCRIPTION
This adds:

- Pulling of [`datasets.json`](https://github.com/4DModeller/fdmr_data/blob/main/datasets.json) from `fdmr_data`
- Slightly cleverer caching of the retrieved datasets by reading the `last_updated` key from the dataset metadata JSON
