### PR TITLE
Move from using `archive` to `untar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Move to use `utils::untar` instead of `archive::extract_archive` due to issues on some Linux systems - [PR #101](https://github.com/4DModeller/fdmr/pull/130)
+
 ### Removed

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,6 @@ Imports:
     spdep,
     gridExtra,
     leaflet,
-    archive,
     shiny,
     stringr,
     shinybusy,

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -67,7 +67,7 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
       utils::download.file(url = data_url, destfile = download_path)
     }
 
-    archive::archive_extract(download_path, dir = extract_path)
+    utils::untar(download_path, exdir = extract_path)
     base::cat("\nTutorial data extracted to ", extract_path, "\n")
   } else {
     stop("Invalid dataset, please see available datasets at https://github.com/4DModeller/fdmr_data")

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -28,7 +28,7 @@ local_get_test_datapath <- function(filename, folder_name) {
     extract_tmp_dir <- fs::path(root_tmp_dir, rand_str)
     fs::dir_create(extract_tmp_dir)
 
-    archive::archive_extract(archive = full_filepath, dir = extract_tmp_dir)
+    utils::untar(full_filepath, exdir = extract_tmp_dir)
 
     folder_contents <- fs::dir_ls(extract_tmp_dir)
 


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Due to isses with using `archive` on some Linux systems this moves to use the `untar` function from `utils`.

* **Please check if the PR fulfills these requirements**

- [x] Closes #122 
- [ ] All code checks passing - `styler` run over code
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Any new libraries added to `DESCRIPTION`
