### PR TITLE
Set default mapper colours to viridis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use of `rgdal` functions migrated to `sf` equivalents due to [`rgdal` retirement](https://r-spatial.org/r/2022/04/12/evolution.html) - [PR #145](https://github.com/4DModeller/fdmr/pull/145)
 - Move to use `utils::untar` instead of `archive::extract_archive` due to issues on some Linux systems - [PR #101](https://github.com/4DModeller/fdmr/pull/130)
+- Default colours for `plot_interactive_map` changed from Blues to Viridis - [PR #161](https://github.com/4DModeller/fdmr/pull/161)
 
 ### Removed

--- a/R/shiny_mapper.R
+++ b/R/shiny_mapper.R
@@ -66,13 +66,12 @@ raster_mapping_app <- function(raster_data = NULL, polygon_data = NULL, date_for
           inputId = "colour_category",
           label = "Palette type",
           choices = c("Sequential", "Diverging", "Qualitative", "Viridis"),
-          selected = "seq"
+          selected = "Viridis"
         ),
         shiny::selectInput(
           inputId = "colour_scheme",
           label = "Color Scheme",
           choices = default_colours,
-          selected = "Blues"
         ),
         shiny::sliderInput(
           inputId = "raster_opacity",


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)

Sets the default colours for the `plot_interactive_map` app to Viridis.

* **Please check if the PR fulfills these requirements**

- [x] Closes #149 
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
