### PR TITLE
Change the x and y-axis labels in the boxplot and density plot functions

### DIFF
--- a/R/plot_priors.R
+++ b/R/plot_priors.R
@@ -50,7 +50,7 @@ plot_priors_boxplot <- function(data) {
     names(fitted_mean_post) <- purrr::map(seq(1, length(data)), function(x) paste("Run", x))
 
     post_rate <- cbind.data.frame(fitted_mean_post)
-    graphics::boxplot(post_rate, xlab = "Prior scenario", ylab = "Rate estimates")
+    graphics::boxplot(post_rate, xlab = "Prior scenario", ylab = "Fitted values")
 }
 
 #' Plot density function
@@ -63,15 +63,15 @@ plot_priors_boxplot <- function(data) {
 #' @keywords internal
 plot_priors_density <- function(data, measurement_data) {
     # Can this be done in a cleaner way? Just create a dataframe from the lists?
-    rate_estimates <- unlist(purrr::map(data, function(x) x$fitted_mean_post))
+    fitted_values <- unlist(purrr::map(data, function(x) x$fitted_mean_post))
     run_strings <- unlist(purrr::map(seq(1, length(data)), function(x) paste("Run", x)))
 
     post_rate <- base::cbind.data.frame(
         "Prior scenario" = rep(run_strings, each = nrow(measurement_data)),
-        "Rate estimates" = rate_estimates
+        "Fitted values" = fitted_values
     )
 
-    ggplot2::ggplot(post_rate, ggplot2::aes(x = `Rate estimates`, color = `Prior scenario`)) +
+    ggplot2::ggplot(post_rate, ggplot2::aes(x = `Fitted values`, color = `Prior scenario`)) +
         ggplot2::geom_density() +
         ggplot2::theme(text = ggplot2::element_text(size = 16))
 }


### PR DESCRIPTION


* **Summary of changes** (Bug fix, feature, docs update, ...)
This is to change the y and x-axis labels in the ```plot_priors_boxplot``` and ``` plot_priors_density``` functions from 'Rate estimates' into a more general name 'Fitted values', because 'Rate estimates' is only suitable for the COVID tutorials. 

* **Please check if the PR fulfills these requirements**

- [x] Closes #184 
- [ ] Tests added and passed
- [ ] All code checks passing - `styler` run over code
- [ ] Vignettes updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Any new libraries added to `DESCRIPTION`
