### PR TITLE
Improve code output for mesh builder tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added check for `time_variable` being passed into model builder Shiny app - [PR #216](https://github.com/4DModeller/fdmr/pull/216)
 - Clear button not clearing all checkboxes in model builder Shiny app - [PR #215](https://github.com/4DModeller/fdmr/pull/215)
 - Corrected code in code pane of model builder Shiny app - [PR #208](https://github.com/4DModeller/fdmr/pull/208)
+- Code displayed in the Code tab of the mesh builder Shiny app couldn't be copied and pasted and used - [PR #233](https://github.com/4DModeller/fdmr/pull/233)
 
 ### Changed
 

--- a/R/shiny_meshbuilder.R
+++ b/R/shiny_meshbuilder.R
@@ -196,6 +196,8 @@ meshbuilder_shiny <- function(
 
     output$mesh_code <- shiny::reactive(
       paste0(
+        "location_data <- spatial_data[, c('", longitude_column, "', '", latitude_column, "')]\n\n",
+        "names(location_data) <- c('LONG', 'LAT')\n\n",
         "mesh <- fmesher::fm_mesh_2d_inla(loc = location_data,
           max.edge = c(", paste0(input$max_edge, collapse = ", "), "),
           cutoff = ", input$cutoff, ",


### PR DESCRIPTION
* **Summary of changes** 
This improves the code tab in the mesh builder tool so that the code can easily be copied and used with no modifications.



* **Please check if the PR fulfills these requirements**

- [x] Closes #217 
- [x] All code checks passing - `styler` run over code
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
