### PR TITLE
fix constrained model run errors

### DIFF
--- a/vignettes/test_fitmodel.Rmd
+++ b/vignettes/test_fitmodel.Rmd
@@ -97,22 +97,20 @@ sp::coordinates(simdf_time) <- c("LONG", "LAT")
 
 ```{r}
 p <- rep(1:length(simdf_space))
-qexp <- stats::qnorm(p, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE)
 model_out <- inlabru::bru(
-    data=simdf_time,
-    components = ~ space(geometry, model = spde) +
-        spacetime(
-            geometry,
-            model = spde,
-            group = time,
-            control.group = list(
-                model = "ar1",
-                hyper = rhoprior
-            ),
-            group_mapper = bru_mapper(mesh)
-        ) +
-        beta_u(1, prec.linear = 1, marginal = bru_mapper_marginal(qexp, rate = 1))
-    ,like(formula = datn ~ space, family = "gaussian")
-    ,like(formula = datn ~ beta_u * space + spacetime, family = "gaussian")
+ components = ~ space(coordinates, model = spde) +
+   spacetime(
+     coordinates,
+     model = spde,
+     group = time,
+     control.group = list(
+       model = "ar1",
+       hyper = rhoprior
+     )
+   ) +
+  beta_u(1, prec.linear = 1),
+ inlabru::like(formula = datn ~ space, family = "gaussian", data=simdf_time),
+ inlabru::like(formula = datn ~ beta_u * space + spacetime, family = "gaussian", data=simdf_time)
 )
+
 ```


### PR DESCRIPTION

* **Summary of changes** (Bug fix, feature, docs update, ...)
To fix the errors when running the constrained model. 
1. Put ‘data= simdf_time’ inside the function like( ). 
2. Delete ‘marginal = bru_mapper_marginal(qexp, rate = 1)’, ‘group_mapper = bru_mapper(mesh)’, and ‘qexp <- stats::qnorm(p, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE)’ simply because they keep reporting errors.

* **Please check if the PR fulfills these requirements**

- [ ] Closes #xxxx (replace xxxx with the GitHub issue number)
- [ ] Tests added and passed
- [ ] All code checks passing - `styler` run over code
- [ ] Vignettes updated/added
- [ ] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
- [ ] Any new libraries added to `DESCRIPTION`
