### PR TITLE
Change the default offset for st_wrap_dateline

### DIFF
--- a/R/util_coords.R
+++ b/R/util_coords.R
@@ -138,7 +138,7 @@ antimeridian_wrapping <- function(polygon_data, crs = 4326, unique_inst = TRUE, 
   }
   
   # Apply the function
-  sf_split <- sf::st_wrap_dateline(sf_data)
+  sf_split <- sf::st_wrap_dateline(sf_data, options = c("WRAPDATELINE=YES", "DATELINEOFFSET=90"))
   
   # Revert sf objects back to sp
   if (base::isTRUE(to_sp)) {


### PR DESCRIPTION
Polar meshes are shown incorrectly north/south of 70 degree latitude if default offset (10 degrees) is used. Increasing the offset to 90 degrees does not negatively impact polygon splitting north/south of 70 degrees and allows to properly plot polar polygons.

* **Summary of changes** (Bug fix, feature, docs update, ...)
Added offset option

* **Please check if the PR fulfills these requirements**

- [x] Closes #286
- [x] Tests added and passed
- [x] All code checks passing - `styler` run over code
