### PR TITLE
`model_viewer` random effect-only model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `model_viewer` app to work with random effect models - [PR #311](https://github.com/4DModeller/fdmr/pull/311)
+- Fixed `model_viewer` app to work with random effect models - [PR #317](https://github.com/4DModeller/fdmr/pull/317)
 - Updated `plot_map_leaflet` to feature the same selection of basemap tiles as `mapview` and fix features not appearing - [PR #310](https://github.com/4DModeller/fdmr/pull/310)
 
 ## [0.2.0] - 2023-12-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `model_viewer` app to work with random effect models - [PR #311](https://github.com/4DModeller/fdmr/pull/311)
 - Updated `plot_map_leaflet` to feature the same selection of basemap tiles as `mapview` and fix features not appearing - [PR #310](https://github.com/4DModeller/fdmr/pull/310)
 
 ## [0.2.0] - 2023-12-19

--- a/R/shiny_modelviewer.R
+++ b/R/shiny_modelviewer.R
@@ -35,6 +35,11 @@ model_viewer_shiny <- function(model_output, mesh, measurement_data, data_distri
   default_colours <- rownames(brewer_palettes[brewer_palettes$cat == "seq", ])
 
   plot_choices <- c("Range", "Stdev", "AR(1)", "Boxplot", "Density", "DIC")
+  if (base::is.null(parsed_model_output[["fixed_mean"]])) {
+    map_choices <- c("Random effect fields")
+  } else {
+    map_choices <- c("Predicted mean fields", "Random effect fields")
+  }
 
   ui <- bslib::page_fluid(
     theme = bslib::bs_theme(bootswatch = "cosmo"),
@@ -56,7 +61,7 @@ model_viewer_shiny <- function(model_output, mesh, measurement_data, data_distri
         shiny::fluidRow(
           shiny::column(
             4,
-            shiny::selectInput(inputId = "map_plot_type", label = "Plot type", choices = c("Predicted mean fields", "Random effect fields"), selected = "Predicted mean fields"),
+            shiny::selectInput(inputId = "map_plot_type", label = "Plot type", choices = map_choices, selected = map_choices[1]),
             shiny::selectInput(inputId = "map_data_type", label = "Data type", choices = c("Poisson", "Gaussian"), selected = data_distribution),
           ),
           shiny::column(


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Added a line to allow random effect-only models to skip the need to provide "Predicted mean fields".

* **Please check if the PR fulfills these requirements**

- [x] Closes #315 
- [x] Tests added and passed
- [x] All code checks passing - `styler` run over code
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
