### PR TITLE
fdmr::retrieve_tutorial_data should not modify the home directory

### DIFF
--- a/R/util_paths.R
+++ b/R/util_paths.R
@@ -65,28 +65,6 @@ clean_path <- function(path, check_exists = FALSE) {
 }
 
 
-#' Checks if a path exists and returns an absolute path
-#'
-#' @param path Path to check
-#'
-#' @return fs::path Expanded absolute path
-#' @keywords internal
-#' 
-check_path <- function(path) {
-  if (is.null(path) || nchar(path) == 0) {
-    stop("Invalid path of zero length given.")
-  }
-  
-  fpath <- fs::path_abs(fs::path_expand(path))
-  
-  if (!fs::file_exists(fpath)) {
-    stop(paste("The path", fpath, "does not exist."))
-  }
-  
-  return(fpath)
-}
-
-
 #' Get path to tutorial data cache folder
 #' 
 #' @param saved Specify the location where user unpacked the data

--- a/R/util_paths.R
+++ b/R/util_paths.R
@@ -2,11 +2,12 @@
 #'
 #' @param dataset Name of dataset
 #' @param filename Name of file
+#' @param temp Save in a temporary directory. Defaults to TRUE. 
 #'
 #' @return fs::path Full filepath
 #' @export
-get_tutorial_datapath <- function(dataset, filename) {
-  tutorial_datapath <- fs::path(get_tutorial_cache_datapath(), dataset)
+get_tutorial_datapath <- function(dataset, filename, temp) {
+  tutorial_datapath <- fs::path(get_tutorial_cache_datapath(temp), dataset)
 
   if (!fs::dir_exists(tutorial_datapath)) {
     stop("Unable to load data, the folder ", toString(tutorial_datapath), " does not exist. Have you run retrieve_tutorial_data?")
@@ -26,15 +27,16 @@ get_tutorial_datapath <- function(dataset, filename) {
 #'
 #' @param dataset Name of dataset
 #' @param filename Name of file
+#' @param temp Use the temporary directory
 #'
 #' @return loaded object
 #' @export
-load_tutorial_data <- function(dataset, filename) {
+load_tutorial_data <- function(dataset, filename, temp) {
   if (!tolower(fs::path_ext(filename)) == "rds") {
     stop("We can only load rds files.")
   }
 
-  fpath <- get_tutorial_datapath(dataset = dataset, filename = filename)
+  fpath <- get_tutorial_datapath(dataset = dataset, filename = filename, temp = temp)
   return(readRDS(fpath))
 }
 
@@ -63,29 +65,43 @@ clean_path <- function(path, check_exists = FALSE) {
 }
 
 #' Get path to tutorial data cache folder
+#' 
+#' @param temp Use the temporary directory
 #'
 #' @return fs::path
 #' @keywords internal
-get_tutorial_cache_datapath <- function() {
-  fs::path(fs::path_home(), "fdmr", "tutorial_data")
+get_tutorial_cache_datapath <- function(temp) {
+  if (temp){
+    fs::path(fs::path_temp(), "fdmr", "tutorial_data")
+  } else{
+    fs::path(fs::path_home(), "fdmr", "tutorial_data")
+  }
 }
 
 #' Get path to downloaded archive cache folder
+#' 
+#' @param temp Use temporary directory
 #'
 #' @return fs::path
 #' @keywords internal
-get_archive_cache_datapath <- function() {
-  fs::path(fs::path_home(), "fdmr", "download_cache")
+get_archive_cache_datapath <- function(temp) {
+  if (temp){
+    fs::path(fs::path_temp(), "fdmr", "download_cache")
+  } else{
+    fs::path(fs::path_home(), "fdmr", "download_cache")
+  }
 }
 
 
 #' Clear both tutorial data and downloaded archive caches
 #'
+#' @param temp Use temporary directory
+#'
 #' @return NULL
 #' @export
-clear_caches <- function() {
-  tut_path <- get_tutorial_cache_datapath()
-  cache_path <- get_archive_cache_datapath()
+clear_caches <- function(temp) {
+  tut_path <- get_tutorial_cache_datapath(temp)
+  cache_path <- get_archive_cache_datapath(temp)
   print(paste("Deleting ", tut_path, cache_path))
   fs::dir_delete(tut_path)
   fs::dir_delete(cache_path)

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -11,7 +11,7 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) 
 
   if (base::isTRUE(save) | base::is.character(save)){
     if (base::is.character(save)) {
-      save_path <- check_path(save)
+      save_path <- clean_path(save, check_exists = TRUE)
       download_cache_folder <- fs::path(save_path, "fdmr", "download_cache")
     } else{
       download_cache_folder <- fs::path(fs::path_home(), "fdmr", "download_cache")
@@ -53,7 +53,7 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) 
 
   if (base::isTRUE(save) | base::is.character(save)){
     if (base::is.character(save)){
-      save_path <- check_path(save)
+      save_path <- clean_path(save, check_exists = TRUE)
       extract_path <- fs::path(save_path, "fdmr", "tutorial_data", dataset)
     } else{
       extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
@@ -93,25 +93,4 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) 
   } else {
     stop("Invalid dataset, please see available datasets at https://github.com/4DModeller/fdmr_data")
   }
-}
-
-#' Checks if a path exists and returns an absolute path
-#'
-#' @param path Path to check
-#'
-#' @return fs::path Expanded absolute path
-#' @keywords internal
-#' 
-check_path <- function(path) {
-  if (is.null(path) || nchar(path) == 0) {
-    stop("Invalid path of zero length given.")
-  }
-  
-  fpath <- fs::path_abs(fs::path_expand(path))
-  
-  if (!fs::file_exists(fpath)) {
-    stop(paste("The path", fpath, "does not exist."))
-  }
-  
-  return(fpath)
 }

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -1,16 +1,21 @@
-#' Retrieve a tutorial dataset and unpacks it to ~/fdmr/tutorial_data
+#' Retrieves a tutorial dataset and unpacks it to a place specified by the user (~/fdmr/tutorial_data)
 #'
 #' @param dataset Name of dataset to retrieve
 #' @param force_update Force retrieval of metadata and dataset
-#' @param save Unpack the dataset to ~/fdmr/tutorial_data
+#' @param save Unpack the dataset to where user specified (character), home directory (TRUE), session's temporary directory (FALSE: default).
 #'
 #' @return NULL
 #' @export
 retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) {
   dataset <- base::tolower(dataset)
 
-  if (save){
-    download_cache_folder <- fs::path(fs::path_home(), "fdmr", "download_cache")
+  if (base::isTRUE(save) | base::is.character(save)){
+    if (base::is.character(save)) {
+      save_path <- check_path(save)
+      download_cache_folder <- fs::path(save_path, "fdmr", "download_cache")
+    } else{
+      download_cache_folder <- fs::path(fs::path_home(), "fdmr", "download_cache")
+    }
   } else {
     download_cache_folder <- fs::path(fs::path_temp(), "fdmr", "download_cache")
     }
@@ -46,8 +51,13 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) 
     jsonlite::write_json(retrieval_info, path = file_metadata_file)
   }
 
-  if (save){
-    extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
+  if (base::isTRUE(save) | base::is.character(save)){
+    if (base::is.character(save)){
+      save_path <- check_path(save, check_exists = TRUE)
+      extract_path <- fs::path(save_path, "fdmr", "tutorial_data", dataset)
+    } else{
+      extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
+    }
   } else {
     extract_path <- fs::path(fs::path_temp(), "fdmr", "tutorial_data", dataset)
     }
@@ -83,4 +93,25 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) 
   } else {
     stop("Invalid dataset, please see available datasets at https://github.com/4DModeller/fdmr_data")
   }
+}
+
+#' Checks if a path exists and returns an absolute path
+#'
+#' @param path Path to check
+#'
+#' @return fs::path Expanded absolute path
+#' @keywords internal
+#' 
+check_path <- function(path) {
+  if (is.null(path) || nchar(path) == 0) {
+    stop("Invalid path of zero length given.")
+  }
+  
+  fpath <- fs::path_abs(fs::path_expand(path))
+  
+  if (!fs::file_exists(fpath)) {
+    stop(paste("The path", fpath, "does not exist."))
+  }
+  
+  return(fpath)
 }

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -2,13 +2,19 @@
 #'
 #' @param dataset Name of dataset to retrieve
 #' @param force_update Force retrieval of metadata and dataset
+#' @param save Unpack the dataset to ~/fdmr/tutorial_data
 #'
 #' @return NULL
 #' @export
-retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
+retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) {
   dataset <- base::tolower(dataset)
 
-  download_cache_folder <- fs::path(fs::path_home(), "fdmr", "download_cache")
+  if (save){
+    download_cache_folder <- fs::path(fs::path_home(), "fdmr", "download_cache")
+  } else {
+    download_cache_folder <- fs::path(fs::path_temp(), "fdmr", "download_cache")
+    }
+
   if (!fs::dir_exists(download_cache_folder)) {
     fs::dir_create(download_cache_folder, recurse = TRUE)
   }
@@ -40,7 +46,12 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE) {
     jsonlite::write_json(retrieval_info, path = file_metadata_file)
   }
 
-  extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
+  if (save){
+    extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)
+  } else {
+    extract_path <- fs::path(fs::path_temp(), "fdmr", "tutorial_data", dataset)
+    }
+  
 
   if (!fs::dir_exists(extract_path)) {
     fs::dir_create(extract_path, recurse = TRUE)

--- a/R/util_retrieve.R
+++ b/R/util_retrieve.R
@@ -53,7 +53,7 @@ retrieve_tutorial_data <- function(dataset, force_update = FALSE, save = FALSE) 
 
   if (base::isTRUE(save) | base::is.character(save)){
     if (base::is.character(save)){
-      save_path <- check_path(save, check_exists = TRUE)
+      save_path <- check_path(save)
       extract_path <- fs::path(save_path, "fdmr", "tutorial_data", dataset)
     } else{
       extract_path <- fs::path(fs::path_home(), "fdmr", "tutorial_data", dataset)

--- a/man/clear_caches.Rd
+++ b/man/clear_caches.Rd
@@ -4,7 +4,10 @@
 \alias{clear_caches}
 \title{Clear both tutorial data and downloaded archive caches}
 \usage{
-clear_caches()
+clear_caches(saved = TRUE)
+}
+\arguments{
+\item{saved}{Specify the location where user unpacked the data}
 }
 \description{
 Clear both tutorial data and downloaded archive caches

--- a/man/get_archive_cache_datapath.Rd
+++ b/man/get_archive_cache_datapath.Rd
@@ -4,7 +4,10 @@
 \alias{get_archive_cache_datapath}
 \title{Get path to downloaded archive cache folder}
 \usage{
-get_archive_cache_datapath()
+get_archive_cache_datapath(saved)
+}
+\arguments{
+\item{saved}{Specify the location where user unpacked the data}
 }
 \value{
 fs::path

--- a/man/get_tutorial_cache_datapath.Rd
+++ b/man/get_tutorial_cache_datapath.Rd
@@ -4,7 +4,10 @@
 \alias{get_tutorial_cache_datapath}
 \title{Get path to tutorial data cache folder}
 \usage{
-get_tutorial_cache_datapath()
+get_tutorial_cache_datapath(saved)
+}
+\arguments{
+\item{saved}{Specify the location where user unpacked the data}
 }
 \value{
 fs::path

--- a/man/get_tutorial_datapath.Rd
+++ b/man/get_tutorial_datapath.Rd
@@ -4,12 +4,14 @@
 \alias{get_tutorial_datapath}
 \title{Return the filepath for a tutorial data file.}
 \usage{
-get_tutorial_datapath(dataset, filename)
+get_tutorial_datapath(dataset, filename, saved = FALSE)
 }
 \arguments{
 \item{dataset}{Name of dataset}
 
 \item{filename}{Name of file}
+
+\item{saved}{Specify the location where user unpacked the data.}
 }
 \value{
 fs::path Full filepath

--- a/man/load_tutorial_data.Rd
+++ b/man/load_tutorial_data.Rd
@@ -4,12 +4,14 @@
 \alias{load_tutorial_data}
 \title{Load data from the tutorial data store}
 \usage{
-load_tutorial_data(dataset, filename)
+load_tutorial_data(dataset, filename, saved = FALSE)
 }
 \arguments{
 \item{dataset}{Name of dataset}
 
 \item{filename}{Name of file}
+
+\item{saved}{Specify the location where user unpacked the data}
 }
 \value{
 loaded object

--- a/man/retrieve_tutorial_data.Rd
+++ b/man/retrieve_tutorial_data.Rd
@@ -2,15 +2,17 @@
 % Please edit documentation in R/util_retrieve.R
 \name{retrieve_tutorial_data}
 \alias{retrieve_tutorial_data}
-\title{Retrieve a tutorial dataset and unpacks it to ~/fdmr/tutorial_data}
+\title{Retrieves a tutorial dataset and unpacks it to a place specified by the user (~/fdmr/tutorial_data)}
 \usage{
-retrieve_tutorial_data(dataset, force_update = FALSE)
+retrieve_tutorial_data(dataset, force_update = FALSE, save = FALSE)
 }
 \arguments{
 \item{dataset}{Name of dataset to retrieve}
 
 \item{force_update}{Force retrieval of metadata and dataset}
+
+\item{save}{Unpack the dataset to where user specified (character), home directory (TRUE), session's temporary directory (FALSE: default).}
 }
 \description{
-Retrieve a tutorial dataset and unpacks it to ~/fdmr/tutorial_data
+Retrieves a tutorial dataset and unpacks it to a place specified by the user (~/fdmr/tutorial_data)
 }

--- a/vignettes/expected_data_structure.Rmd
+++ b/vignettes/expected_data_structure.Rmd
@@ -18,6 +18,7 @@ In this tutorial, we will show the expected data structure for running the Bayes
 In the [COVID-19 tutorial](https://4dmodeller.github.io/fdmr/articles/covid.html), we aim to fit a Bayesian spatio-temporal model to predict the COVID-19 infection rates across mainland England over space and time, and investigate the impacts of socioeconomic, demographic and environmental factors on COVID-19 infection. We load the dataset `covid19_data` and the type of this object is a `data.frame`. 
 
 ```{r classcovidat}
+fdmr::retrieve_tutorial_data(dataset = "covid")
 covid19_data <- fdmr::load_tutorial_data(dataset = "covid", filename = "covid19_data.rds")
 class(covid19_data)
 ```


### PR DESCRIPTION
* **Summary of changes** (Bug fix, feature, docs update, ...)
Closes issue 326. Allows user to select the directory by giving a valid path, save to the temporary directory (default), or save to the home directory.

* **Please check if the PR fulfills these requirements**

- [x] Closes #326
- [x] Tests added and passed
- [x] Added an entry in the latest `CHANGELOG.md` file if fixing a bug or adding a new feature
